### PR TITLE
Set transient correctly on each call of storePluginData

### DIFF
--- a/src/common/project/node.coffee
+++ b/src/common/project/node.coffee
@@ -25,6 +25,9 @@ class Node extends SyncObject
 			@[key] = data
 			if transient and key not in @transientProperties
 				@transientProperties.push key
+			else if not transient and key in @transientProperties
+				index = @transientProperties.indexOf key
+				@transientProperties.splice index, 1
 
 	setModelHash: (hash) =>
 		return @next => @modelHash = hash

--- a/test/project/nodeTests.coffee
+++ b/test/project/nodeTests.coffee
@@ -161,6 +161,21 @@ describe 'Node tests', ->
 				to.deep.have.property('[0].packet.data.pluginName').
 				that.deep.equals(data)
 
+		it 'should store plugin data if transient set to false in later call', ->
+			dataPackets.nextIds.push 'abcdefgh'
+			dataPackets.nextPuts.push true
+			node = new Node()
+			data = {random: ['plugin', 'data']}
+			node
+			.storePluginData 'pluginName', {}, true
+			.storePluginData 'pluginName', data, false
+			node.save().then ->
+				expect(dataPackets.calls).to.equal(2)
+				expect(dataPackets.createCalls).to.have.length(1)
+				expect(dataPackets.putCalls).
+				to.deep.have.property('[0].packet.data.pluginName').
+				that.deep.equals(data)
+
 	describe 'node transform', ->
 		it 'should provide reasonable default transforms', ->
 			dataPackets.nextIds.push 'abcdefgh'


### PR DESCRIPTION
Previously a once set to transient property could never be made persistent
