### PR TITLE
Disable depth sorting of objects to have a better top-view-rendering

### DIFF
--- a/src/client/renderer.coffee
+++ b/src/client/renderer.coffee
@@ -90,6 +90,7 @@ class Renderer
 			preserveDrawingBuffer: true
 			canvas: document.getElementById globalConfig.renderAreaId
 		)
+		@threeRenderer.sortObjects = false
 
 		@threeRenderer.setSize @size().width, @size().height
 


### PR DESCRIPTION
Fix #404
Rendering from below the plate is still error-prone.
