### PR TITLE
Disable mouse interaction when being in build and stability view

### DIFF
--- a/src/plugins/editController/editController.coffee
+++ b/src/plugins/editController/editController.coffee
@@ -39,6 +39,7 @@ class EditController
 			)
 
 	onPointerEvent: (event, eventType) =>
+		return false if @interactionDisabled
 		return false if not @nodeVisualizer? or not @pointEventHandler?
 
 		ignoreInvisible = event.buttons isnt pointerEnums.buttonStates.right


### PR DESCRIPTION
closes #444 
