### PR TITLE
*production hotfix* Update express to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "errorhandler": "^1.2.2",
     "es6-collections": "^0.5.1",
     "es6-promise": "^2.0.0",
-    "express": "^4.9.8",
+    "express": "^4.12.3",
     "filesaver.js": "^0.1.1",
     "font-awesome": "^4.3.0",
     "fs-promise": "^0.3.1",


### PR DESCRIPTION
Update express to latest version.
Because: server was crashing when getting a HEAD request from uptimerobot. solved with new express version

closes #495 
