### PR TITLE
set correct log level in production

### DIFF
--- a/src/client/main.coffee
+++ b/src/client/main.coffee
@@ -13,7 +13,8 @@ globalConfig = require '../common/globals.yaml'
 
 if process.env.NODE_ENV is 'development'
 	log.enableAll()
-
+else
+	log.setLevel 'warn'
 
 commandFunctions = {
 	initialModel: (value) ->


### PR DESCRIPTION
Despite the documentation of loglevel, 0 (i.e. trace) seems to be the default level in production mode.
--> set it explicitely in both modes
