### PR TITLE
Feature/find mergeable neighbors extension for plates

### DIFF
--- a/src/plugins/newBrickator/pipeline/Layout/BrickLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/BrickLayouter.coffee
@@ -63,12 +63,12 @@ class BrickLayouter extends Layouter
 		return mergeableNeighbors
 
 	_findMergeableNeighborsInDirection: (brick, dir, widthFn, lengthFn) =>
+		if widthFn(brick.getSize()) > 2 and lengthFn(brick.getSize()) >= 2
+			return null
+
 		voxels = brick.voxels
 		mergeVoxels = new Set()
 		mergeBricks = new Set()
-
-		if widthFn(brick.getSize()) > 2 and lengthFn(brick.getSize()) >= 2
-			return null
 
 		# Find neighbor voxels, noMerge if any is empty
 		voxelIter = voxels.values()

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -68,6 +68,9 @@ class PlateLayouter extends Layouter
 	# @see Brick
 	###
 	_findMergeableNeighborsInDirection: (brick, dir, widthFn, lengthFn) ->
+		if widthFn(brick.getSize()) > 2 and lengthFn(brick.getSize()) >= 2
+			return null
+
 		neighbors = brick.getNeighbors(dir)
 		return null if neighbors.size is 0
 

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -82,8 +82,6 @@ class PlateLayouter extends Layouter
 				checkResult.length, brick.getSize().z)
 			return neighbors
 
-		console.log 'mergeable but invalid size'
-
 		# If the neighbors are mergeable except for unvalid brick dimensions
 		# test the neighbors' neighbors
 		firstNeighborsLength = checkResult.length
@@ -99,8 +97,7 @@ class PlateLayouter extends Layouter
 
 		if Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
 				firstNeighborsLength + checkResult.length, brick.getSize().z)
-			console.log 'merging neighborsNeighbors'
-			return DataHelper.union(neighbors, neighborsNeighbors)
+			return DataHelper.union([neighbors, neighborsNeighbors])
 
 		return null
 

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -70,17 +70,19 @@ class PlateLayouter extends Layouter
 		neighborsInDirection = brick.getNeighbors(dir)
 		return null if neighborsInDirection.size is 0
 
-		# Check that the neighbors together don't exceed this brick's width
 		totalNeighborsWidth = 0
 
 		neighborIter = neighborsInDirection.values()
 		while neighbor = neighborIter.next().value
 			neighborSize = neighbor.getSize()
-			return null if neighborSize.z != brick.getSize().z
-			return null if neighbor.getPosition().z != brick.getPosition().z
+			# Checks for z dimension
+			return null unless neighborSize.z is brick.getSize().z
+			return null unless neighbor.getPosition().z is brick.getPosition().z
+			# Add width to accumulative width
 			totalNeighborsWidth += widthFn neighborSize
 
-		return null if totalNeighborsWidth != widthFn(brick.getSize())
+		# Check that the neighbors together match this brick's width
+		return null unless totalNeighborsWidth == widthFn(brick.getSize())
 
 		minWPos = widthFn(brick.getPosition())
 		maxWPos = minWPos + widthFn(brick.getSize()) - 1
@@ -89,18 +91,19 @@ class PlateLayouter extends Layouter
 
 		neighborIter = neighborsInDirection.values()
 		while neighbor = neighborIter.next().value
-			neighborLength ?= lengthFn(neighbor.getSize())
 			return null if widthFn(neighbor.getPosition()) < minWPos
 			neighborWidth = widthFn(neighbor.getPosition()) +
 				widthFn(neighbor.getSize()) - 1
 			return null if neighborWidth > maxWPos
-			return null if lengthFn(neighbor.getSize()) != neighborLength
+			# Check that all neighbors have the same length
+			neighborLength ?= lengthFn(neighbor.getSize())
+			return null unless lengthFn(neighbor.getSize()) is neighborLength
 
-		if Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
+		if !Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
 				neighborLength, brick.getSize().z)
-			return neighborsInDirection
-		else
 			return null
+
+		return neighborsInDirection
 
 
 

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -4,6 +4,7 @@ Brick = require '../Brick'
 Voxel = require '../Voxel'
 Random = require '../Random'
 Layouter = require './Layouter'
+DataHelper = require '../DataHelper'
 
 
 ###

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -78,7 +78,7 @@ class PlateLayouter extends Layouter
 				checkResult.length, brick.getSize().z)
 			return neighbors
 
-		log.debug 'mergeable but invalid size'
+		console.log 'mergeable but invalid size'
 
 		# If the neighbors are mergeable except for unvalid brick dimensions
 		# test the neighbors' neighbors
@@ -86,8 +86,8 @@ class PlateLayouter extends Layouter
 
 		neighborsNeighbors = new Set()
 		neighbors.forEach (neighbor) ->
-			neighbor.getNeighbors(dir).forEach (neighborsNeighbor)
-				neighborsNeighbors.add neighborsNeighbor
+			neighbor.getNeighbors(dir).forEach (nNeighbor) ->
+				neighborsNeighbors.add nNeighbor
 
 		# Check the neighbors of the neighbors
 		checkResult = @_checkNeighbors brick, neighborsNeighbors, widthFn, lengthFn
@@ -95,7 +95,7 @@ class PlateLayouter extends Layouter
 
 		if Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
 				firstNeighborsLength + checkResult.length, brick.getSize().z)
-			log.debug 'merging neighborsNeighbors'
+			console.log 'merging neighborsNeighbors'
 			return DataHelper.union(neighbors, neighborsNeighbors)
 
 		return null

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -71,37 +71,33 @@ class PlateLayouter extends Layouter
 		return null if neighborsInDirection.size is 0
 
 		# Check that the neighbors together don't exceed this brick's width
-		width = 0
+		totalNeighborsWidth = 0
 
 		neighborIter = neighborsInDirection.values()
 		while neighbor = neighborIter.next().value
 			neighborSize = neighbor.getSize()
 			return null if neighborSize.z != brick.getSize().z
 			return null if neighbor.getPosition().z != brick.getPosition().z
-			width += widthFn neighborSize
+			totalNeighborsWidth += widthFn neighborSize
 
-		return null if width != widthFn(brick.getSize())
+		return null if totalNeighborsWidth != widthFn(brick.getSize())
 
-		# If they have the same accumulative width
-		# check if they are in the correct positions,
-		# i.e. no spacing between neighbors
+		minWPos = widthFn(brick.getPosition())
+		maxWPos = minWPos + widthFn(brick.getSize()) - 1
 
-		minWidth = widthFn(brick.getPosition())
-		maxWidth = minWidth + widthFn(brick.getSize()) - 1
-
-		length = null
+		neighborLength = null
 
 		neighborIter = neighborsInDirection.values()
 		while neighbor = neighborIter.next().value
-			length ?= lengthFn(neighbor.getSize())
-			return null if widthFn(neighbor.getPosition()) < minWidth
+			neighborLength ?= lengthFn(neighbor.getSize())
+			return null if widthFn(neighbor.getPosition()) < minWPos
 			neighborWidth = widthFn(neighbor.getPosition()) +
 				widthFn(neighbor.getSize()) - 1
-			return null if neighborWidth > maxWidth
-			return null if lengthFn(neighbor.getSize()) != length
+			return null if neighborWidth > maxWPos
+			return null if lengthFn(neighbor.getSize()) != neighborLength
 
 		if Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
-				length, brick.getSize().z)
+				neighborLength, brick.getSize().z)
 			return neighborsInDirection
 		else
 			return null

--- a/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
+++ b/src/plugins/newBrickator/pipeline/Layout/PlateLayouter.coffee
@@ -72,40 +72,33 @@ class PlateLayouter extends Layouter
 
 		# Check that the neighbors together don't exceed this brick's width
 		width = 0
-		noMerge = false
 
-		neighborsInDirection.forEach (neighbor) ->
+		neighborIter = neighborsInDirection.values()
+		while neighbor = neighborIter.next().value
 			neighborSize = neighbor.getSize()
-			if neighborSize.z != brick.getSize().z
-				noMerge = true
-			if neighbor.getPosition().z != brick.getPosition().z
-				noMerge = true
+			return null if neighborSize.z != brick.getSize().z
+			return null if neighbor.getPosition().z != brick.getPosition().z
 			width += widthFn neighborSize
-		return null if noMerge
+
+		return null if width != widthFn(brick.getSize())
 
 		# If they have the same accumulative width
 		# check if they are in the correct positions,
 		# i.e. no spacing between neighbors
-		return null if width != widthFn(brick.getSize())
 
 		minWidth = widthFn(brick.getPosition())
-
 		maxWidth = minWidth + widthFn(brick.getSize()) - 1
 
 		length = null
 
-		invalidSize = false
-		neighborsInDirection.forEach (neighbor) ->
+		neighborIter = neighborsInDirection.values()
+		while neighbor = neighborIter.next().value
 			length ?= lengthFn(neighbor.getSize())
-			if widthFn(neighbor.getPosition()) < minWidth
-				invalidSize = true
+			return null if widthFn(neighbor.getPosition()) < minWidth
 			neighborWidth = widthFn(neighbor.getPosition()) +
 				widthFn(neighbor.getSize()) - 1
-			if neighborWidth > maxWidth
-				invalidSize = true
-			if lengthFn(neighbor.getSize()) != length
-				invalidSize = true
-		return null if invalidSize
+			return null if neighborWidth > maxWidth
+			return null if lengthFn(neighbor.getSize()) != length
 
 		if Brick.isValidSize(widthFn(brick.getSize()), lengthFn(brick.getSize()) +
 				length, brick.getSize().z)


### PR DESCRIPTION
1x4 plates can now merge into 1x6 plates (with two 1x1 plates as consecutive neighbors, skipping the 1x5 invalid brick size) in one step
before, the two 1x1 plates had to be merged into a 2x1 plate first to merge with the 1x4 plate
