### PR TITLE
Improve transparency rendering of model 

### DIFF
--- a/src/plugins/nodeVisualizer/modelVisualization.coffee
+++ b/src/plugins/nodeVisualizer/modelVisualization.coffee
@@ -35,6 +35,12 @@ class ModelVisualization
 			parent.add solid
 			parent.solid = solid
 
+			# visible black lines, again!
+			lineObject = new THREE.Mesh geometry
+			lines = new THREE.EdgesHelper lineObject, 0x000000, 30
+			lines.material = @coloring.objectLineMatFront
+			parent.add lines
+
 		_addWireframe = (geometry, parent) =>
 			wireframe = new THREE.Object3D()
 
@@ -57,10 +63,11 @@ class ModelVisualization
 				.then (modelObject) =>
 					geometry = threeConverter.toStandardGeometry modelObject
 
-					if @globalConfig.rendering.showModel
-						_addSolid geometry, @threeNode
 					if @globalConfig.rendering.showShadowAndWireframe
 						_addWireframe geometry, @threeNode
+
+					if @globalConfig.rendering.showModel
+						_addSolid geometry, @threeNode
 
 					threeHelper.applyNodeTransforms node, @threeNode
 

--- a/src/plugins/nodeVisualizer/modelVisualization.coffee
+++ b/src/plugins/nodeVisualizer/modelVisualization.coffee
@@ -28,6 +28,9 @@ class ModelVisualization
 	getSolid: =>
 		@threeNode.solid
 
+	getSolidLines: =>
+		@threeNode.solidLines
+
 	_createVisualization: (node) =>
 
 		_addSolid = (geometry, parent) =>
@@ -40,6 +43,7 @@ class ModelVisualization
 			lines = new THREE.EdgesHelper lineObject, 0x000000, 30
 			lines.material = @coloring.objectLineMatFront
 			parent.add lines
+			parent.solidLines = lines
 
 		_addWireframe = (geometry, parent) =>
 			wireframe = new THREE.Object3D()

--- a/src/plugins/nodeVisualizer/nodeVisualizer.coffee
+++ b/src/plugins/nodeVisualizer/nodeVisualizer.coffee
@@ -16,6 +16,7 @@ class NodeVisualizer
 	constructor: ->
 		# rendering properties
 		@brickVisualizations = {}
+		@modelVisualizations = {}
 		@fidelity = 0
 
 	init: (@bundle) =>
@@ -212,6 +213,11 @@ class NodeVisualizer
 		for nodeId, brickVisualization of @brickVisualizations
 			brickVisualization.setFidelity @fidelity
 
+		# Turn off second wireframe pass when pipeline is rendered
+		for nodeId, modelVisualization of @modelVisualizations
+			lines = modelVisualization.getSolidLines()
+			lines.visible = not @usePipeline
+
 	# called by newBrickator when an object's data structure is modified
 	objectModified: (node, newBrickatorData) =>
 		@_getCachedData(node)
@@ -292,6 +298,11 @@ class NodeVisualizer
 			)
 		@brickVisualizations[node.id] = brickVisualization
 
+		modelVisualization = new ModelVisualization(
+			@bundle.globalConfig, node, modelThreeNode, @coloring
+		)
+		@modelVisualizations[node.id] = modelVisualization
+
 		data = {
 			initialized: false
 			node: node
@@ -299,9 +310,7 @@ class NodeVisualizer
 			brickShadowThreeNode: brickShadowThreeNode
 			modelThreeNode: modelThreeNode
 			brickVisualization: brickVisualization
-			modelVisualization: new ModelVisualization(
-				@bundle.globalConfig, node, modelThreeNode, @coloring
-			)
+			modelVisualization: modelVisualization
 		}
 
 		return data

--- a/src/plugins/nodeVisualizer/visualization/Coloring.coffee
+++ b/src/plugins/nodeVisualizer/visualization/Coloring.coffee
@@ -47,15 +47,20 @@ module.exports = class Coloring
 			opacity: 0.4
 			depthFunc: THREE.GreaterDepth
 		)
+		@objectShadowMat.depthWrite = false
+
 		@_setPolygonOffset @objectShadowMat, +3, +3
 
 		lineMaterialGenerator = new LineMatGenerator()
 		@objectLineMat = lineMaterialGenerator.generate 0x000000
 		@objectLineMat.linewidth = 2
-		@objectLineMat.transparent = true
-		@objectLineMat.opacity = 0.1
-		@objectLineMat.depthFunc = THREE.GreaterDepth
+		@objectLineMat.depthFunc = THREE.AlwaysDepth
 		@objectLineMat.depthWrite = false
+
+		@objectLineMatFront = lineMaterialGenerator.generate 0x000000
+		@objectLineMatFront.linewidth = 2
+		@objectLineMatFront.depthFunc = THREE.LessEqualDepth
+		@objectLineMatFront.depthWrite = true
 
 		@_createBrickMaterials()
 


### PR DESCRIPTION
while maintaining outlines in default rendering.
Prevents the shadow from rendering itself onto the original model. Fixes hidden outline by drawing them a second time.

Comparison:
Old and busted (non!)
![non](https://cloud.githubusercontent.com/assets/236678/8640090/0c449a82-28ec-11e5-9c46-5b747cc25f56.PNG)

Hot and new (ah oui!)
![oui](https://cloud.githubusercontent.com/assets/236678/8640092/1790f430-28ec-11e5-8856-f1781560a544.PNG)
